### PR TITLE
use openconnect-gp's new mechanism for specifying a cookie field

### DIFF
--- a/gp-okta.py
+++ b/gp-okta.py
@@ -305,7 +305,7 @@ def main():
 	userauthcookie = paloalto_getconfig(conf, s, saml_username, prelogin_cookie)
 	log('portal-userauthcookie: {0}'.format(userauthcookie))
 	
-	cmd = '\nopenconnect --protocol=gp -u "{0}" --userauthcookie="{1}" {2}'
+	cmd = '\necho "{1}" | openconnect --protocol=gp -u "{0}"/portal:portal-userauthcookie --passwd-on-stdin {2}'
 	print(cmd.format(saml_username, userauthcookie, conf.get('vpn_url')))
 
 


### PR DESCRIPTION
I added this mechanism in the `fun_with_cookie` branch. See:

* https://github.com/dlenski/openconnect/commits/fun_with_cookies
* https://github.com/dlenski/openconnect/pull/98#issuecomment-380923571

Please test this PR with the `fun_with_cookies` branch of `openconnect`.

Assuming it works as it should, I'll merge it into the main `globalprotect` development branches and submit it upstream.