### PR TITLE
Various improvements mostly related to Docker usage

### DIFF
--- a/gp-okta.conf
+++ b/gp-okta.conf
@@ -21,6 +21,11 @@ gateway = NEWYORK1-GW
 #totp.google = ABCDEFGHIJKLMNOP
 #totp.symantec = ABCDEFGHIJKLMNOP
 
+# --- this is for storing a single one-time password. Not very useful
+# in a config file, but potentially very useful for overriding with
+# GP_TOTP_CODE in the environment.
+#totp_code =
+
 # --- certificates
 # any defined "*_cert" is path to readable and unencrypted certificate file.
 # "vpn_url_cert" and "okta_url_cert" are used to verify relevant URLs.

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,33 +1,7 @@
 #!/usr/bin/env bash
 
-conf_username=`grep username gp-okta.conf | awk -F \= '{print $2}' | tr -d " "`
-conf_password=`grep password gp-okta.conf | awk -F \= '{print $2}' | tr -d " "`
-totp_okta=`grep totp.okta gp-okta.conf | awk -F \= '{print $2}' | tr -d " "`
-totp_google=`grep totp.google gp-okta.conf | awk -F \= '{print $2}' | tr -d " "`
-
-haystack="okta google"
-
-if [[ -z "${totp_okta}" && -z "${totp_google}" ]]; then
-    read -p "Enter Second auth numbers (okta or google), (prepend with needed provider e.g okta_1234): " totp
-    if [[ "${totp}" ]]; then
-        totp_choice=`echo ${totp} | awk  -F _ '{ print $1 }'`
-        totp_numbers=`echo ${totp} | awk  -F _ '{ print $2 }'`
-        if [[ -n "echo $haystack|grep $totp_choice" ]]; then
-            echo "${totp_choice}"
-            if [[ "${totp_numbers}" && ${totp_choice} ]]; then
-                sed -i "s/totp.${totp_choice}.*/totp.${totp_choice} = ${totp_numbers}/g" gp-okta.conf
-            fi
-        else
-            echo "Unsupported second auth choosed"
-            exit 1
-        fi
-
-    else
-        echo "Something failed with parsing second auth"
-        exit 1
-    fi
-
-fi
+conf_username=$(grep "^username" gp-okta.conf | awk -F \= '{print $2}' | tr -d " ")
+conf_password=$(grep "^password" gp-okta.conf | awk -F \= '{print $2}' | tr -d " ")
 
 ### detect where username is filled in
 if [[ "${conf_username}" ]]; then
@@ -45,20 +19,47 @@ fi
 
 if [[ -z "${conf_password}" && -z "${GP_PASSWORD}" ]]; then
     read -s -p "Enter Okta password: " GP_PASSWORD
+    echo
+fi
+
+# If no TOTP secrets are specified, prompt for OTP.
+totp_secrets=$(grep "^totp." gp-okta.conf | awk -F \= '{print $2}' | tr -d " ")
+if [[ -z "${totp_secrets}" ]]; then
+    read -p "Enter MFA OTP code: " totp
 fi
 
 echo
 
-
 docker run \
     -d \
+    --name=gp-okta \
     --rm \
     --privileged \
     --net=host \
     --cap-add=NET_ADMIN \
     --device /dev/net/tun \
-    -e GP_PASSWORD=${GP_PASSWORD} \
     -e GP_USERNAME=${GP_USERNAME} \
+    -e GP_PASSWORD=${GP_PASSWORD} \
+    -e GP_TOTP_CODE=${totp} \
+    -e GP_EXECUTE=1 \
+    -e GP_OPENCONNECT_CMD=/usr/local/sbin/openconnect \
     -v /etc/resolv.conf:/etc/resolv.conf \
-    -v ${PWD}:/openconnect/gp-okta \
-    gp-okta
+    -v ${PWD}/gp-okta.conf:/etc/gp-okta.conf \
+    gp-okta \
+    > /dev/null
+
+# Watch output for successful, for a little while at least
+( timeout 30 docker logs -f gp-okta & ) | sed '/ESP tunnel connected/q'
+
+# If container is gone, something went awry
+echo
+echo
+if [ -z "$(docker ps -q -f name=gp-okta)" ]; then
+    echo
+    echo
+    echo "VPN failed to start!"
+    exit 1
+else
+    echo "VPN running"
+    exit 0
+fi

--- a/stop-docker.sh
+++ b/stop-docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+container=$(docker ps -q -f name=gp-okta)
+if [ -z "${container}" ]; then
+    echo "VPN is not running!"
+    exit 1
+fi
+
+# Watch output for close-down output
+( timeout 30 docker logs -f --since 0s gp-okta & )
+
+docker stop gp-okta > /dev/null
+
+echo
+echo
+echo "VPN stopped."


### PR DESCRIPTION
Main program:
 - Handle SIGINT/SITGERM better (explicitly terminate openconnect).
   Without this, stopping the Docker container wouldn't allow
   openconnect to restore /etc/resolv.conf.
 - Allow one-time code to be specified in conf file/environment

Docker wrapper scripts:
 - Use environment to pass one-time code (old approach of overriding
   the secret value in conf file didn't work)
 - Identify whether code is needed more generically (if ANY totp.xxxx
   secrets are specified, skip the code)
 - Skip commented lines in conf file when looking for secrets, username,
   etc.
 - Output appropriate Docker logfiles when stopping and starting
 - Add stop-docker.sh script to cleanly bring down VPN, with logs

Docker image:
 - Use python 3, based on python/debian-slim base image
 - Multi-stage build to keep openconnect build tools out of final image
 - Only gp-okta.conf needs to be mounted into image now
 - Update URL for retrieving vpnc-script (old git repository has
   gone away)
 - Disable buffering for cleaner output