### PR TITLE
Fix extracting references from regex match

### DIFF
--- a/gp-okta.py
+++ b/gp-okta.py
@@ -152,7 +152,7 @@ def err(s):
 	sys.exit(1)
 
 def _remx(c, v): return re.search(r'\s*' + v + r'\s*"?[=:]\s*(?:"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\')', c)
-_refx = lambda mx: to_b(mx.group(1)).decode('unicode_escape').strip()
+_refx = lambda mx: to_b(mx.group(1) if mx.group(1) is not None else mx.group(2)).decode('unicode_escape').strip()
 
 def parse_xml(xml):
 	# type: (str) -> etree._Element


### PR DESCRIPTION
The regex uses separate capture groups for alternative expressions that match a single-quoted or a double-quoted string. This is more robust with strings that may contain quotes.

However the code using the match objects doesn't currently take the two capture groups into account and always expects the results in group 1, which only matches double-quoted strings.

This change introduces a check so that if group 1 is None, the function will use the matched substring in group 2.

Closes #36