### PR TITLE
Add `enable_unsafe_legacy_renegotiation` param to work around

### DIFF
--- a/gp-okta.conf
+++ b/gp-okta.conf
@@ -40,6 +40,10 @@ gateway = NEWYORK1-GW
 # it will be used to verify gateways and passed to openconnect executable.
 #
 #certs = certs.pem
+#
+# For servers that don't support Renegotiation Indication Extension (RFC 5746)
+# and openssl v3 clients, this might need to be 1
+#enable_unsafe_legacy_renegotiation = 0
 
 # --- execution
 # "execute" (0/1) defines if openconnect (as specified with "openconnect_cmd"


### PR DESCRIPTION
```
requests.exceptions.SSLError: HTTPSConnectionPool(host='vpn.mycompany.biz', port=443): Max retries exceeded with url: /global-protect/prelogin.esp (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:997)')))
```